### PR TITLE
release: @react-native-oh-tpl/react-native-nfc-manager@3.15.0-0.0.1

### DIFF
--- a/harmony/nfc_manager/oh-package.json5
+++ b/harmony/nfc_manager/oh-package.json5
@@ -1,6 +1,6 @@
 {
-  "name": "nfc_manager",
-  "version": "1.0.0",
+  "name": "@react-native-oh-tpl/react-native-nfc-manager",
+  "version": "3.15.0-0.0.1",
   "description": "Please describe the basic information.",
   "main": "Index.ets",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-nfc-manager",
-  "version": "3.15.0",
+  "name": "@react-native-oh-tpl/react-native-nfc-manager",
+  "version": "3.15.0-0.0.1",
   "description": "A NFC module for react native.",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
1.添加oh_pckage.json的version和name
2.适配@rnoh/react-native-openharmony
  [Version Info]:
  react-native-harmony: 0.72.27
  DevEco Studio: 5.0.3.400
  SDK: HarmonyOS NEXT Developer Beta1
  ROM: 3.0.0.25